### PR TITLE
Add crisp pixels option to css for

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,15 @@
     <style>
         html,
         body {
-            margin: 0;
-            padding: 0;
+          margin: 0;
+          padding: 0;
+          image-rendering: optimizeSpeed;              /* Older versions of FF */
+          image-rendering: -moz-crisp-edges;           /* FF 6.0+ */
+          image-rendering: -webkit-optimize-contrast;  /* Webkit (non standard naming) */
+          image-rendering: -o-crisp-edges;             /* OS X & Windows Opera (12.02+) */
+          image-rendering: crisp-edges;                /* Possible future browsers. */
+          -ms-interpolation-mode: nearest-neighbor;    /* IE (non standard naming) */
+          image-rendering: pixelated;                  /* Chrome 41 */
         }
     </style>
 </head>


### PR DESCRIPTION
This is for simulating older resolutions where the pixel edges are visible, like Super Mario. For newer games that use vectors or the best resolution, you might not want this.