### PR TITLE
Update eslint and babel in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.3.4",
     "@babel/polyfill": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-env": "^7.3.4",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.0",
-    "browser-sync": "^2.24.7",
+    "browser-sync": "^2.26.3",
     "browser-sync-webpack-plugin": "^2.2.2",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.2",
-    "eslint": "^5.5.0",
+    "eslint": "^5.15.0",
     "eslint-plugin-import": "^2.14.0",
     "expose-loader": "^0.7.5",
     "html-webpack-plugin": "^3.2.0",
@@ -29,6 +29,10 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "phaser": "3.12.0",
     "phaser-animated-tiles": "^2.0.2"
   }


### PR DESCRIPTION
this does not include related package json lockfile versions. but it does fix the eslint and cover some version updates flagged by the npm auditor. 

I didn't have any problems after doing this - it made PHPStorm behave a lot better with linting automatically.